### PR TITLE
Fix events with 2 'dtstart' for all-day events in ics generation

### DIFF
--- a/events/ics.py
+++ b/events/ics.py
@@ -13,10 +13,10 @@ def get_ics_of_events(request):
     for event in Event.objects.all():
         ics_event = ICSEvent()
         ics_event.add('summary', '%s [%s]' % (event.title, event.source))
-        ics_event.add('dtstart', event.start)
         if event.start.hour == 0 and event.start.minute == 0:
             ics_event.add('dtstart', event.start.date())
         else:
+            ics_event.add('dtstart', event.start)
             if event.end:
                 ics_event.add('dtend', event.end)
             else:


### PR DESCRIPTION
12:43  [C4ptainCrunch] Bram: #SKANDALE ! ton ics généré par hackeragenda est pas valide !
12:49  [C4ptainCrunch] Bram: t'as parfois 2 DTSTART : https://github.com/Psycojoker/hackeragenda/blob/master/events/ics.py#L18
12:49  [C4ptainCrunch] ce qui est interdit
12:50 [C4ptainCrunch] Bram: http://www.ietf.org/rfc/rfc2445 section 4.6.1
