### PR TITLE
settings: enable auth and session middlewares in DEBUG mode

### DIFF
--- a/hackeragenda/settings.py
+++ b/hackeragenda/settings.py
@@ -70,9 +70,7 @@ TEMPLATE_LOADERS = (
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
-    #'django.contrib.sessions.middleware.SessionMiddleware',
     #'django.middleware.csrf.CsrfViewMiddleware',
-    #'django.contrib.auth.middleware.AuthenticationMiddleware',
     #'django.contrib.messages.middleware.MessageMiddleware',
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
@@ -160,6 +158,9 @@ PREDEFINED_FILTERS["code"] = {
 if DEBUG:
     MIDDLEWARE_CLASSES += (
         'debug_toolbar.middleware.DebugToolbarMiddleware',
+        # Needed for the admin interface
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
     )
 
 INTERNAL_IPS = ('127.0.0.1',)


### PR DESCRIPTION
Needed to be able to use the admin interface.
