### PR TITLE
[fix] facebook: try using the 'description' field

### DIFF
--- a/events/management/commands/fetch_events.py
+++ b/events/management/commands/fetch_events.py
@@ -209,7 +209,10 @@ def generic_facebook(org_name, fb_group, background_color, text_color, agenda, t
     if not description:
         # Use the FB group description
         group = graph.get(fb_group)
-        description = group['about']
+        if 'about' in group:
+            description = group['about']
+        elif 'description' in group:
+            description = group['description']
 
     return event_source(background_color, text_color, agenda=agenda, description=description, url="https://www.facebook.com/" + fb_group)(fetch, org_name)
 


### PR DESCRIPTION
Facebook pages and groups don't use the same description field for some
reason. We should be able to use both.
