### PR TITLE
[mod] add general purpose JSON api

### DIFF
--- a/events/urls.py
+++ b/events/urls.py
@@ -2,12 +2,13 @@ from django.conf.urls import patterns, url, include
 from events.api import EventResource
 from .feeds import NextEventsFeed
 from .ics import get_ics_of_events
-from .views import EventListView
+from .views import EventListView, get_fullcalendar_json, get_events_in_json
 
 event_resource = EventResource()
 
 urlpatterns = patterns('events.views',
-    url(r'^events.json$', 'get_events_in_json', name='events_json'),
+    url(r'^events_fullcalendar.json$', get_fullcalendar_json, name='events_json'),
+    url(r'^events.json$', get_events_in_json, name='events_api_json'),
     url(r'^events.rss$', NextEventsFeed(), name='events_rss'),
     url(r'^events.ics$', get_ics_of_events, name='events_ics'),
     url(r'^events.html$', EventListView.as_view(), name='events_render'),

--- a/events/views.py
+++ b/events/views.py
@@ -34,8 +34,15 @@ class EventListView(ListView):
         return context
 
 
-def get_events_in_json(request):
+def get_fullcalendar_json(request):
     return HttpResponse(json.dumps(map(event_to_fullcalendar_format, filter_events(request=request, queryset=Event.objects.filter(agenda=settings.AGENDA)))), mimetype="application/json")
+
+
+def get_events_in_json(request):
+    return HttpResponse(json.dumps(
+        map(event_to_json_format, filter_events(request=request,
+                                                queryset=Event.objects.filter(agenda=settings.AGENDA)))),
+        mimetype="application/json")
 
 
 def event_to_fullcalendar_format(event):
@@ -56,4 +63,16 @@ def event_to_fullcalendar_format(event):
         else:
             to_return["end"] = (event.start + timedelta(hours=3)).strftime("%F %X")
 
+    return to_return
+
+
+def event_to_json_format(event):
+    "JSON format for general use, in contrast to the fullcalendar version."
+    # Patches the JSON for fullcalendar with extra info
+    to_return = event_to_fullcalendar_format(event)
+    to_return.update({
+        key: getattr(event, key)
+        for key in ("title", "source", "location")
+        if getattr(event, key) is not None
+        })
     return to_return


### PR DESCRIPTION
Extends the JSON API used by fullcalendar with additional fields (location, separated title and source) for general purpose use of the API.

```json
{
    "allDay": false,
    "end": "2013-09-21 14:00:00",
    "start": "2013-09-21 11:00:00",
    "color": "#3A87AD",
    "title": "Journée du Logiciel Libre",
    "url": "http://www.agendadulibre.be/events/196",
    "source": "agenda_du_libre_be",
    "agenda": "be",
    "textColor": "white",
    "location": "Saint-Josse, Bruxelles-Capitale"
}
```