### PR TITLE
Add URL to ICS export

### DIFF
--- a/events/ics.py
+++ b/events/ics.py
@@ -27,6 +27,7 @@ def get_ics_of_events(request):
                 ics_event.add('dtend', event.start + timedelta(hours=3))
         ics_event.add('dtstamp', event.start)
         ics_event['uid'] = event.url
+        ics_event['url'] = event.url
         ics_event['categories'] = event.source
 
         cal.add_component(ics_event)


### PR DESCRIPTION
Hi, i would like to have hackeragenda exporting a more standard .ics (iCalendar) by populating the url field with the event url.